### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Protect your keyboard with the most advance system. Disable the keyboard in seconds and continue using your system. The extension requires xinput as a dependency",
   "uuid": "keyboard-cat-defense@onel.github.io",
   "shell-version": [
-    "3.36"
+    "3.36", "43"
   ],
   "url": "https://github.com/onel/keyboard-cat-defense",
   "version": 1


### PR DESCRIPTION
Added current default Debian 12 gnome-shell version 43. I tested this extension on gnome-shell 43.9 and it works great! Unfortunately, this extension can't be enabled in Debian 12 without explicitly specifying the gnome-shell version in metadata.js
![image](https://github.com/user-attachments/assets/374532ac-8dc3-4da7-a371-ae57ac56e5d0)

This commit fixes that problem and makes this extension work out of the box on Debian 12 systems
